### PR TITLE
Make example docker command copy-paste friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ If you wish to install YouTransfer in your own environment without any modificat
 You can run the application with the following command:
 
 ````
-docker run -d 
--v [path_to_upload_folder]:/opt/youtransfer/uploads 
--v [path_to_config_folder]:/opt/youtransfer/config 
--p 80:5000 
+docker run -d \
+-v [path_to_upload_folder]:/opt/youtransfer/uploads \
+-v [path_to_config_folder]:/opt/youtransfer/config \
+-p 80:5000 \
 remie/youtransfer:stable
 ````
 


### PR DESCRIPTION
A very minor edit to the readme to make the example docker command copy-and-paste friendly.

I've added a backslash `\` to escape the newline characters so that the example command can be copy and pasted. Otherwise it needs to be manually entered or copied line-by-line.

